### PR TITLE
feat(eval): GLM_WORKERS env knob

### DIFF
--- a/eval_sadeed_glm.py
+++ b/eval_sadeed_glm.py
@@ -132,7 +132,8 @@ def main() -> None:
             return i, call(session, key, inputs[i])
 
         n_written = 0
-        with ThreadPoolExecutor(max_workers=8) as ex:
+        workers = int(os.environ.get("GLM_WORKERS", "8"))
+        with ThreadPoolExecutor(max_workers=workers) as ex:
             futures = {ex.submit(work, i): i for i in todo}
             for fut in as_completed(futures):
                 i, pred = fut.result()


### PR DESCRIPTION
8 by default; lower it for overloaded endpoints. glm-4.7-flash currently sits behind sustained 429s (code 1305) — 8 concurrent workers burn the retry budget into empty rows. Empties remain self-healing on resume per the #65 guard.