### PR TITLE
docs: E6 rung register statuses — gate FAILED at 5.8057

### DIFF
--- a/TODO.publish/02-e6-verdict.md
+++ b/TODO.publish/02-e6-verdict.md
@@ -1,10 +1,15 @@
 # 02 — E6 verdict (constant-budget register diversification)
 
-Status: IN FLIGHT (2026-09-02). Training COMPLETE — all 11,073 steps,
-final CE ~0.003-0.008 (run-008-tashkeela-mix; /tmp/e6_distill2.log).
-`modal_distill.py::main` does not chain the final eval, so
-`evaluate_der` was launched separately (/tmp/e6_evalder.log,
-resumable, writes final_eval.json).
+Status: COMPLETE (2026-09-02). Training finished all 11,073 steps;
+`evaluate_der` (launched separately — `main` doesn't chain it)
+returned **student 5.8057 / teacher 2.289** (n=1200). **GATE FAILED
+at 5.8057** (gate <=4.5218, control 4.8218, E5's failed 5.0853);
+NOT ADOPTED. Paired bootstrap student−teacher +3.2388pp, CI
+[2.939, 3.575]. Prediction (4.45-4.75) missed. Recorded:
+EXPERIMENTS.md E6 status, PUBLICATION-NOTES §8 negative pair
+(E5+E6) + Paper-B paragraph (the causal test failed in the swap
+direction; G2b's 48k add is the live test). ara-diac-small-2.x
+material NOT triggered — release question moot.
 
 ## Registered (EXPERIMENTS.md, gate before launch)
 

--- a/TODO.training-work/04-label-scale-rung.md
+++ b/TODO.training-work/04-label-scale-rung.md
@@ -1,8 +1,12 @@
 # 04 — Label-scale rung (A1a): diversify the student's domain mix
 
-Status: TO BUILD. The E2/E3/E4 factorial attributes the remaining
-~2.0pp of client-tier gap to domain coverage; the current mix is
-news-heavy (r5-units/domain.txt + replay.txt, teacher-labeled by r7).
+Status: COMPLETE (2026-09-02) — **GATE FAILED: 5.8057** (gate
+<=4.5218; control 4.8218; worse than E5's 5.0853). NOT ADOPTED.
+Swapping 8k news units for classical Tashkeela at constant 30k
+total HURT (−0.98pp vs control); teacher reproduced at 2.289.
+Verdict recorded in EXPERIMENTS.md E6 + PUBLICATION-NOTES §8/§B
+(the E5/E6 data-vs-architecture negative pair). Direction shifts to
+the add side (G2b, 48k total, in flight). See TODO.publish/02.
 
 ## Design
 


### PR DESCRIPTION
Register status updates for the E6 verdict (interscript-ml #140 carries the record): TODO.publish/02 and TODO.training-work/04 closed as GATE FAILED 5.8057 vs gate 4.5218 / control 4.8218; direction shifts to G2b (48k add).