### PR TITLE
docs: dependency-security decision memo — the 56 Dependabot alerts

### DIFF
--- a/TODO.publish/05-owner-decisions.md
+++ b/TODO.publish/05-owner-decisions.md
@@ -11,21 +11,26 @@ instruction naming it.
 1. **GKD ordering** — the last registered training lever (SOTA
    strategy 2025: "GKD is next"). Runs after E6's verdict so the
    rung ladder stays one-variable-at-a-time. Owner decides: launch
-   now, after E6, or wait for the E5/E6 writeup.
-2. **glm-4.7 partial-coverage policy** — if the 429 wall never
-   clears: record as partial-coverage row with disclosure, or drop
-   the row. (Default per protocol honesty: disclose coverage in the
-   row itself.)
-3. **ara-diac-small-2.x release** — iff E6 passes the gate
-   (<= 4.5218). Version number is always the owner's decision
-   (rubygems lesson applies to model indices too).
+   now, after E6, or wait for the E5/E6 writeup. (E6 now closed
+   failed 2026-09-02 — see TODO.publish/02.)
+2. **glm-4.7 partial-coverage policy** — RESOLVED: the fetch
+   completed 1,200/1,200 (12 passes), full row recorded.
+3. **ara-diac-small-2.x release** — RESOLVED for E6 (gate failed,
+   no release). G2a (4.5701) has its own export entry (ml #136);
+   G2b pending. Version numbers remain the owner's.
 4. **head32 swap-in shape** — in-place + index-v2 vs parallel
    `-int8-head32` ids. Five-of-five rebuilds done with flip CIs;
    swap-in is a release-side act.
 5. **fp16 index entries for ara-diac-2.0** — export-side, low risk,
    owner sequencing.
-6. **rababa PR backlog** — #51/#52/#53/#48/#49/#26 (from
-   TODO.training-work/08).
+6. **rababa dependency-security decision (56 Dependabot alerts)** —
+   see TODO.publish/06 for the memo: keep-frozen+dismiss (A) vs
+   bump+re-record legacy goldens (B, via PRs #51-53) vs root-floor
+   raises (C). Evidence: #52/#53 fail on Ruby golden mismatches at
+   torch 2.13 = the re-validation gate firing.
+7. **rababa PR backlog** — #48 (user's Modernize, green), #26
+   (user's 2021 rspec PR), #49 (merged 2026-09). User's own PRs
+   untouched by design.
 
 ## Standing constraints (do not re-derive)
 

--- a/TODO.publish/06-dependency-security-decisions.md
+++ b/TODO.publish/06-dependency-security-decisions.md
@@ -1,0 +1,54 @@
+# 06 — Dependency-security decisions (the 56 Dependabot alerts)
+
+Status: ANALYZED 2026-09-03 — decision memo for the owner. Everything
+below is owner territory (version/requirements contract); nothing was
+executed. Evidence gathered; PRs #51/#52/#53 are the live decision
+vehicles.
+
+## Where the alerts live
+
+All 56 (4 critical, 20 high, 18 moderate, 14 low) target two FROZEN
+legacy inference environments + the root floors:
+
+- `python/arabic/requirements.txt` and `python/hebrew/requirements.txt`
+  — 2021-era exact pins: torch==1.9.0 (2 CRITICAL advisories incl.
+  the <=1.13.0 one), onnx==1.9.0, numpy==1.19.5, tqdm==4.56.0
+- root `pyproject.toml` floors: torch>=2.4,<3 / onnx>=1.17 /
+  onnxruntime>=1.20 / numpy>=1.26,<3 / tqdm>=4.66
+
+interscript-ml and interscript.org have ZERO open alerts. This is a
+rababa-only decision.
+
+## The constraint (why the pins are frozen)
+
+`python/pyproject.toml` comment: torch/onnxruntime are version-coupled
+to the trained model weights; bumping requires re-validating
+inference. CONFIRMED LIVE: dependabot PRs #52/#53 (torch 1.9.0 ->
+2.13.0) fail their Ruby matrix with golden-output mismatches
+(`expect(diacritizer.diacritize_text(source)).to eq target`) — the
+legacy CBHG weights diacritize DIFFERENTLY under torch 2.13. That is
+the documented re-validation gate firing, not CI flake.
+
+Counter-evidence: `python-arabic.yml` installs with
+`--upgrade-strategy eager` and its latest run is GREEN — the PYTHON
+diacritize path validates fine at latest torch; only the Ruby-bridge
+golden strings are numerics-pinned to the 1.9 era.
+
+## The decision (owner picks one)
+
+| Option | Clears alerts | Cost |
+|---|---|---|
+| A. Keep frozen + dismiss the legacy-file alerts (reason: vulnerable_code_not_in_use — eager CI is the live validator; the == pins are provenance) | alerts dismissed, not cleared | none; alert noise gone after dismissal (owner act via UI/API) |
+| B. Merge #51/#52/#53 (torch 2.13.0 / onnx 1.22.0) + re-record the Ruby goldens at the new numerics | all legacy-file alerts | published behavior of legacy models changes; every consumer golden shifts |
+| C. Raise root floors only (torch>=2.6, onnx>=1.22, tqdm>=4.66.3) | root-floor alerts | cuts off torch 2.4/2.5 consumers; requirements change |
+
+My read: **A** for the legacy files (matches the repo's own
+eager-CI validation posture), **C's floors only if** no consumer pins
+rababa against torch<2.6 — that's a usage question only you can
+answer. B should not be taken casually: it silently redefines what
+the legacy models output.
+
+## Fixed alongside (not owner territory)
+
+- python/pyproject.toml pointed at TODO.complete/19-torch-2x.md which
+  does not exist — pointer corrected to this memo.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{ name = "Ribose Inc.", email = "open.source@ribose.com" }]
 
 # Runtime dependencies are pinned per-language under python/{arabic,hebrew}/requirements.txt
 # because torch and onnxruntime are version-coupled to the trained model weights.
-# Bumping them requires re-validating inference — see TODO.complete/19-torch-2x.md.
+# Bumping them requires re-validating inference — see TODO.publish/06-dependency-security-decisions.md.
 dependencies = []
 
 [optional-dependencies]


### PR DESCRIPTION
Analysis of the 56 open Dependabot alerts (4 critical / 20 high / 18 moderate / 14 low) — a decision memo, not a fix: every remediation path changes a version/requirements contract, which is the owner call (python/pyproject.toml documents the weights-coupling gate).

Findings:
- All alerts target python/{arabic,hebrew}/requirements.txt (frozen 2021 pins: torch==1.9.0, onnx==1.9.0, numpy==1.19.5, tqdm==4.56.0) plus the root pyproject floors. interscript-ml and the site have zero alerts.
- The re-validation gate is REAL: PRs #52/#53 (torch -> 2.13.0) fail the Ruby matrix with diacritize_text golden mismatches — legacy CBHG weights behave differently under new torch. Meanwhile python-arabic CI (eager upgrade) is green at latest — only the Ruby-bridge goldens are numerics-pinned.
- Options tabled in TODO.publish/06: (A) keep frozen + dismiss legacy-file alerts (matches the eager-CI validation posture; my read), (B) merge #51-53 + re-record goldens (silently redefines legacy model output), (C) raise root floors (cuts torch<2.6 consumers).
- Fixed alongside: dangling TODO.complete/19-torch-2x.md pointer in python/pyproject.toml (file never existed in-repo); register 05 refreshed with resolved items (E6 closed failed, glm-4.7 row complete).