### PR TITLE
chore(deps): raise security floors — torch>=2.6, onnx>=1.22, tqdm>=4.66.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,12 @@ license = { text = "BSD-2-Clause" }
 authors = [{ name = "Ribose Inc.", email = "open.source@ribose.com" }]
 
 dependencies = [
-  "torch>=2.4,<3",
+  "torch>=2.6,<3",
   "numpy>=1.26,<3",
   "omegaconf>=2.3,<3",
-  "onnx>=1.17",
+  "onnx>=1.22",
   "onnxruntime>=1.20",
-  "tqdm>=4.66",
+  "tqdm>=4.66.3",
   "pyyaml>=6.0",
 ]
 


### PR DESCRIPTION
Owner decision C from TODO.publish/06, implemented as tabled: root floors raised to torch>=2.6, onnx>=1.22, tqdm>=4.66.3 (numpy>=1.26 already clears its advisories). Clears the critical torch advisory and the onnx/tqdm alerts against the root manifest. Known residual: torch advisories whose patches landed in 2.9.1/2.10/2.13 still flag the >=2.6,<2.13 window — raising to 2.13 would cut far more consumers, so left as approved. Legacy python/*/requirements.txt pins untouched (option-A territory; PRs #51-53 close as superseded).