### PR TITLE
docs(substantiate): CONTINUE.md — standing idempotent continuation prompt

### DIFF
--- a/TODO.substantiate/CONTINUE.md
+++ b/TODO.substantiate/CONTINUE.md
@@ -1,0 +1,47 @@
+# CONTINUE — the standing, idempotent continuation prompt
+
+This is the fixed continuation prompt. It is stateless: re-run it any
+number of times, in any session — it derives state from this register,
+the Modal volumes, and git; it never relies on conversation memory and
+never changes per iteration. Copy the block below verbatim.
+
+---
+
+Work the register: `interscript/rababa/TODO.substantiate/README.md` is
+the index of record. For every item whose Status is not COMPLETE, do
+that item's next open step exactly as its file and its linked
+registrations specify; skip anything already done (statuses in the
+README are the source of truth — update them in the same PR that
+lands each step). Derive everything else from live state, not memory:
+
+1. GKD (item 03, spec `ara-diac-small-2-gkd`, implemented in
+   interscript-ml): if no run dir `rababa_arabic_distill_small/
+   run-011-r7-muon-gkd` exists on the `rababa-checkpoints` volume AND
+   fewer than two ephemeral GPU apps are running (`modal app list`),
+   launch: `cd /Users/mulgogi/src/interscript/ml-qwen-feat && nohup
+   modal run --detach src/gpu/modal_distill.py::main --spec
+   ara-diac-small-2-gkd > /tmp/gkd_distill.log 2>&1 &`. If the run dir
+   exists and training is past step 11073 but no `final_eval.json`,
+   run `::evaluate_der --spec-id ara-diac-small-2-gkd` the same way
+   (main does not chain it). When final_eval.json exists, verdict vs
+   the registered gate (adopt <= 4.5218; honest band to 4.8218;
+   prediction 4.30-4.65) into EXPERIMENTS.md E-GKD + PUBLICATION-
+   NOTES Paper-B lever table + TODO.substantiate statuses; mark item
+   03 COMPLETE either way. Never launch if the budget is full; just
+   report the blocker.
+2. G2b watch (item 04): read `final_eval.json` under every
+   `run-*tashkeela*` / 48k run dir on the volume (tiny modal
+   volume-read, timeout 120). If a G2b verdict exists and is NOT yet
+   recorded in EXPERIMENTS.md, record it + the E6-swap vs G2b-add
+   pair in PUBLICATION-NOTES Paper-B framing, mark item 04 COMPLETE;
+   otherwise leave WATCHING and report progress (step count from
+   `modal app logs`).
+3. If every item is COMPLETE: report the register closed and stop.
+   Do not invent new work; new items require the owner.
+
+Standing rules: numbers only from `docs/RESULTS.md` (the ledger);
+commit via PRs off fresh `origin/main` (rebase-merge; squash if the
+branch carries merge commits); never commit to main; no AI
+attribution in commits; `git add` explicit paths only; Modal always
+`--detach`, <= 2 big GPU apps; version numbers and releases are the
+owner's; the GPU worktree is `/Users/mulgogi/src/interscript/ml-qwen-feat`.

--- a/TODO.substantiate/README.md
+++ b/TODO.substantiate/README.md
@@ -11,9 +11,14 @@ COMPLETE and closed: TODO.training-work, TODO.publish.
 |---|---|---|---|---|
 | [01](01-paper-currency.md) | Three latex papers current with the Sept results | P1 — highest value | COMPLETE (rababa #80) — venue formatting/submission is the owner's | nothing |
 | [02](02-ce-curve-comparison.md) | E5/E6 CE-curve vs run-006 at matched steps | P1 — quick, mechanical | COMPLETE (ml #146) | nothing |
-| [03](03-gkd-arming.md) | GKD rung: arm spec + registration (launch = owner) | P2 | ARMED (ml #147) — launch on owner word | owner ordering |
+| [03](03-gkd-arming.md) | GKD rung: arm spec + registration (launch = owner) | P2 | IMPLEMENTED (ml #148) — launch queued on GPU slot; driver = [CONTINUE.md](CONTINUE.md) step 1 | GPU slot |
 | [04](04-g2b-watch.md) | G2b verdict watch + cross-recording | P2 | WATCHING — no final_eval yet as of 2026-09-03; rung census: 8.26/7.56/4.83/5.29/5.08/4.57/5.09/5.81/5.78/73.95 | other agents' run |
 | [05](05-project-closeouts.md) | Issue closures #38/#41 + legacy alert dismissals | P3 | COMPLETE — #38/#41 closed with cross-refs; all 56 Dependabot alerts auto-FIXED by #48+#78 on rescan (no dismissals needed) | nothing |
+
+## Continuation
+
+[CONTINUE.md](CONTINUE.md) is the standing idempotent prompt — stateless,
+repeatable, unchanged across iterations. Point any future session at it.
 
 ## Working rules (unchanged)
 


### PR DESCRIPTION
Adds TODO.substantiate/CONTINUE.md — the fixed, stateless continuation prompt (derive state from register + volume + git; never per-iteration edits), and updates item 03 to IMPLEMENTED (ml #148) with the launch queued behind the current GPU occupancy.