### PR TITLE
docs(substantiate): CONTINUE driver run-id fix (GKD = run-012)

### DIFF
--- a/TODO.substantiate/CONTINUE.md
+++ b/TODO.substantiate/CONTINUE.md
@@ -16,7 +16,7 @@ lands each step). Derive everything else from live state, not memory:
 
 1. GKD (item 03, spec `ara-diac-small-2-gkd`, implemented in
    interscript-ml): if no run dir `rababa_arabic_distill_small/
-   run-011-r7-muon-gkd` exists on the `rababa-checkpoints` volume AND
+   run-012-r7-muon-gkd` exists on the `rababa-checkpoints` volume AND
    fewer than two ephemeral GPU apps are running (`modal app list`),
    launch: `cd /Users/mulgogi/src/interscript/ml-qwen-feat && nohup
    modal run --detach src/gpu/modal_distill.py::main --spec


### PR DESCRIPTION
Corrects the CONTINUE.md driver after the GKD run-id rename (run-012, ml #151): the prompt stays stateless — its reference now matches the spec on main.