### PR TITLE
docs(substantiate): driver signals — best/ over step counts; G2b unchained-eval rule

### DIFF
--- a/TODO.substantiate/CONTINUE.md
+++ b/TODO.substantiate/CONTINUE.md
@@ -20,10 +20,11 @@ lands each step). Derive everything else from live state, not memory:
    fewer than two ephemeral GPU apps are running (`modal app list`),
    launch: `cd /Users/mulgogi/src/interscript/ml-qwen-feat && nohup
    modal run --detach src/gpu/modal_distill.py::main --spec
-   ara-diac-small-2-gkd > /Users/mulgogi/gkd_distill.log 2>&1 &`. If the run dir
-   exists and training is past step 11073 but no `final_eval.json`,
-   run `::evaluate_der --spec-id ara-diac-small-2-gkd` the same way
-   (main does not chain it). When final_eval.json exists, verdict vs
+   ara-diac-small-2-gkd > /Users/mulgogi/gkd_distill.log 2>&1 &`. If the
+   run dir exists with a best/ checkpoint but no final_eval.json
+   (training complete, eval unchained), run
+   `::evaluate_der --spec-id ara-diac-small-2-gkd` the same way
+   (main does not chain it; never rely on step counts — they drift). When final_eval.json exists, verdict vs
    the registered gate (adopt <= 4.5218; honest band to 4.8218;
    prediction 4.30-4.65) into EXPERIMENTS.md E-GKD + PUBLICATION-
    NOTES Paper-B lever table + TODO.substantiate statuses; mark item
@@ -31,11 +32,15 @@ lands each step). Derive everything else from live state, not memory:
    report the blocker.
 2. G2b watch (item 04): read `final_eval.json` under every
    `run-*tashkeela*` / 48k run dir on the volume (tiny modal
-   volume-read, timeout 120). If a G2b verdict exists and is NOT yet
-   recorded in EXPERIMENTS.md, record it + the E6-swap vs G2b-add
-   pair in PUBLICATION-NOTES Paper-B framing, mark item 04 COMPLETE;
-   otherwise leave WATCHING and report progress (step count from
-   `modal app logs`).
+   volume-read, timeout 120). If G2b training completed (best/
+   checkpoint exists) but no final_eval.json and no app is running
+   it, run `::evaluate_der --spec-id ara-diac-small-2-6ep-tashkeela`
+   the same detach way (the other agents' rung; the eval is read-only
+   decode + scoring, safe to complete). If a G2b verdict exists and
+   is NOT yet recorded in EXPERIMENTS.md, record it + the E6-swap vs
+   G2b-add pair in PUBLICATION-NOTES Paper-B framing, mark item 04
+   COMPLETE; otherwise leave WATCHING and report progress (step
+   count from `modal app logs`).
 3. If every item is COMPLETE: report the register closed and stop.
    Do not invent new work; new items require the owner.
 


### PR DESCRIPTION
Two driver robustness fixes from live evidence: (1) GKD eval trigger keyed on a best/ checkpoint instead of a step count (this run totals 10,995, not run-006's 11,073 — counts drift, artifacts don't); (2) G2b rule: when the other agents' training completes unchained (best/ exists, no final_eval, no app), the driver runs the read-only evaluate_der for their spec.
