### PR TITLE
docs(substantiate): item 04 COMPLETE — G2b verdict 4.8231

### DIFF
--- a/TODO.substantiate/README.md
+++ b/TODO.substantiate/README.md
@@ -12,7 +12,7 @@ COMPLETE and closed: TODO.training-work, TODO.publish.
 | [01](01-paper-currency.md) | Three latex papers current with the Sept results | P1 — highest value | COMPLETE (rababa #80) — venue formatting/submission is the owner's | nothing |
 | [02](02-ce-curve-comparison.md) | E5/E6 CE-curve vs run-006 at matched steps | P1 — quick, mechanical | COMPLETE (ml #146) | nothing |
 | [03](03-gkd-arming.md) | GKD rung: arm spec + registration (launch = owner) | P2 | IMPLEMENTED (ml #148) — launch queued on GPU slot; driver = [CONTINUE.md](CONTINUE.md) step 1 | GPU slot |
-| [04](04-g2b-watch.md) | G2b verdict watch + cross-recording | P2 | WATCHING — no final_eval yet as of 2026-09-03; rung census: 8.26/7.56/4.83/5.29/5.08/4.57/5.09/5.81/5.78/73.95 | other agents' run |
+| [04](04-g2b-watch.md) | G2b verdict watch + cross-recording | P2 | COMPLETE (2026-09-04) — verdict 4.8231 recorded (ml PR pending); domain hypothesis negative both directions
 | [05](05-project-closeouts.md) | Issue closures #38/#41 + legacy alert dismissals | P3 | COMPLETE — #38/#41 closed with cross-refs; all 56 Dependabot alerts auto-FIXED by #48+#78 on rescan (no dismissals needed) | nothing |
 
 ## Continuation


### PR DESCRIPTION
Register status: item 04 (G2b watch) COMPLETE — verdict 4.8231 (flat vs 3ep control, 0.25pp worse than news-only G2a at matched epochs), recorded in interscript-ml EXPERIMENTS + PUBLICATION-NOTES by the companion PR. Domain-coverage hypothesis closed negative in both directions; only GKD remains on the register.
